### PR TITLE
add the option to strip the prefix

### DIFF
--- a/tests/test_Router.py
+++ b/tests/test_Router.py
@@ -43,6 +43,19 @@ class TestRouter(unittest.TestCase):
         self.assertEqual(router.get_route_app({'HTTP_HOST': 'localhost', 'PATH_INFO': '/foobar/'}), app2)
         self.assertEqual(router.get_route_app({'HTTP_HOST': 'localhost', 'PATH_INFO': '/spam/'}), app3)
 
+    def test_startswith_strip_route(self):
+        from wsgigo import AppRouter
+
+        app1 = TestWsgiApp('First app')
+        app2 = TestWsgiApp('Second app')
+
+        router = AppRouter(app1)
+        router.add_startswith(app2, '/foobar/', strip_startswith=True)
+
+        environ = {'HTTP_HOST': 'localhost', 'PATH_INFO': '/foobar/cheese'}
+        self.assertEqual(router.get_route_app(environ), app2)
+        self.assertEqual(environ['PATH_INFO'], '/cheese')
+
     def test_custom_router(self):
         from wsgigo import AppRouter, Route
 

--- a/wsgigo/__init__.py
+++ b/wsgigo/__init__.py
@@ -10,11 +10,12 @@ class Route:
 
 
 class StandardRoute(Route):
-    def __init__(self, app: callable, startswith: str = None, hostname: str = None):
+    def __init__(self, app: callable, startswith: str = None, hostname: str = None, strip_startswith: bool = False):
         super().__init__(app)
 
         self.startswith = startswith
         self.hostname = hostname
+        self.strip_startswith = strip_startswith
 
     def claim(self, environ):
         path = environ['PATH_INFO']
@@ -22,6 +23,11 @@ class StandardRoute(Route):
 
         if self.startswith:
             if path.startswith(self.startswith):
+                if self.strip_startswith:
+                    path = path[len(self.startswith):]
+                    if not path.startswith('/'):
+                        path = '/' + path
+                    environ['PATH_INFO'] = path
                 return True
         if self.hostname:
             if host.lower() == self.hostname.lower():
@@ -36,8 +42,8 @@ class AppRouter:
     def add_route(self, route: Route):
         self.routes.append(route)
 
-    def add_startswith(self, app, pattern):
-        self.routes.append(StandardRoute(app, startswith=pattern))
+    def add_startswith(self, app, pattern, strip_startswith=False):
+        self.routes.append(StandardRoute(app, startswith=pattern, strip_startswith=strip_startswith))
 
     def add_hostname(self, app, hostname):
         self.routes.append(StandardRoute(app, hostname=hostname))


### PR DESCRIPTION
I want to route to two applications, but they shouldn't have to know about it, so I want to strip the prefix I have added to the URL off before passing it along to the application.